### PR TITLE
Remove language from code snippets

### DIFF
--- a/css.md
+++ b/css.md
@@ -24,7 +24,7 @@ If you think there should be any changes to these, then raise them with the team
 
 Use soft tabs set to 4 spaces.
 
-```css
+```
 /* Bad */
 .selector {
 ..display: flex;
@@ -38,7 +38,7 @@ Use soft tabs set to 4 spaces.
 
 Place 1 space before the leading brace and place 1 space after the colon of a declaration.
 
-```css
+```
 /* Bad */
 .selector{
     position:relative;
@@ -52,14 +52,14 @@ Place 1 space before the leading brace and place 1 space after the colon of a de
 
 Place an empty newline at the end of the file.
 
-```css
+```
 /* Bad */
 .selector {
     clear: both;
 }
 ```
 
-```css
+```
 /* Good */
 .selector {
     clear: both;
@@ -86,7 +86,7 @@ The chosen code format ensures that code is: easy to read; easy to clearly comme
 + Place the closing brace of a ruleset in the same column as the first character of the ruleset
 + Separate each ruleset by a blank line
 
-```css
+```
 /* Bad */
 .selector-1, .selector-2, .selector-3 { display: block; font-family: helvetica,arial,sans-serif; background: #fff; background: linear-gradient(#fff,rgba(0,0,0,0.8)) }
 .selector-a, .selector-b { padding: 10px }
@@ -111,7 +111,7 @@ The chosen code format ensures that code is: easy to read; easy to clearly comme
 
 ## <a name='declaration-order'>Declaration order</a>
 
-```css
+```
 .selector {
 	/* Positioning */
 	position
@@ -320,7 +320,7 @@ All code should be lowercase unless a react component name contains capitals: Th
 
 **_(Note: for more info on our approach to handling SASS for react components, see our [Styleguide](https://octopus.energy/_styleguide))_**
 
-```css
+```
 /* Bad */
 BODY {
     margin: 0;
@@ -355,7 +355,7 @@ Most of these are fairly obvious, but are also part of the Stylelint tests and s
 
 ## <a name='comments'>Comments</a>
 
-```css
+```
 /* -----------------------------------------------------------------------------
  * Section block
  * -------------------------------------------------------------------------- */
@@ -368,7 +368,7 @@ Most of these are fairly obvious, but are also part of the Stylelint tests and s
 
 **Example**:
 
-```css
+```
 /* ==========================================================================
    Typography
    ========================================================================== */

--- a/html.md
+++ b/html.md
@@ -9,7 +9,7 @@ Contents:
 
 Instead of:
 
-```html+django
+```
 {% if obj.channel == "FIELD_SALES" %}
     ...
 {% endif %}
@@ -17,7 +17,7 @@ Instead of:
 
 add a property to the model/class to allow:
 
-```html+django
+```
 {% if obj.is_field_sales %}
     ...
 {% endif %}

--- a/python.md
+++ b/python.md
@@ -50,7 +50,7 @@ The values stored in the database should be uppercase and separated with
 underscores. A human-readable version should also be added in the tuples
 provided to the field.
 
-```python
+```
 TELESALES, FIELD_SALES = "TELESALES", "FIELD_SALES"
 CHANNEL_CHOICES = (
     (TELESALES, "Telesales"),
@@ -73,7 +73,7 @@ view/form/serializer classes names with `View`/`Form`/`Serializer`.
 
 Within a calling module, it's nicer to have:
 
-```python
+```
 from django.views import generic
 from . import forms
 
@@ -83,7 +83,7 @@ class SetPassword(generic.FormView):
 
 rather than:
 
-```python
+```
 from django.views import generic
 from . import forms
 
@@ -143,7 +143,7 @@ properties into these groups using a comment:
 
 Contrived example:
 
-```python
+```
 class SomeModel(models.Model):
     name = models.CharField(max_length=255)
 
@@ -218,7 +218,7 @@ unique, use `.objects.filter`.
 
 Don't do this:
 
-```python
+```
 try:
     thing = Thing.objects.get(name=some_value)
 except Thing.DoesNotExist:
@@ -229,7 +229,7 @@ else:
 
 unless the `name` field has a `unique=True`. Instead do this:
 
-```python
+```
 things = Thing.objects.filter(name=some_value)
 if things.count() == 1:
     things.first().do_something()
@@ -255,7 +255,7 @@ are some rules-of-thumb:
 
 A property method should not trigger a database call. Don't do this:
 
-```python
+```
 @property
 def num_children(self):
     return self.kids.count()
@@ -266,7 +266,7 @@ Use a method instead.
 Property methods should generally just derive a new value from the fields on
 the model. A common use-case is predicates like:
 
-```python
+```
 @property
 def is_closed(self):
     return self.status == self.CLOSED
@@ -301,7 +301,7 @@ Here's a few tips.
 - Consider including links to related resources that might be a common next step
   for the user. HTML can be included in flash messages
 
-  ```python
+  ```
   msg = (
       '<h4>Some heading</h4>'
       '<p>An action was performed. Now do you want to <a href="%s">do the next thing</a>.</p>'
@@ -324,7 +324,7 @@ itself (like a request user-agent).
 
 Example:
 
-```python
+```
 result = do_something(foo, bar)
 
 events.publish(
@@ -357,7 +357,7 @@ See [Sentry's docs](https://docs.sentry.io/clients/python/integrations/logging/#
 
 Don't do this:
 
-```python
+```
 try:
     do_something()
 except UnableToDoSomething as e:
@@ -366,7 +366,7 @@ except UnableToDoSomething as e:
 
 or this:
 
-```python
+```
 try:
     do_something()
 except UnableToDoSomething as e:
@@ -375,7 +375,7 @@ except UnableToDoSomething as e:
 
 Instead, do this:
 
-```python
+```
 try:
     do_something()
 except UnableToDoSomething:
@@ -386,7 +386,7 @@ If you do need to format data into the message string, don't use the `%`
 operator. Instead, pass the parameters as args:
 https://docs.sentry.io/clients/python/integrations/logging/#usage
 
-```python
+```
 try:
     do_something(arg=x)
 except UnableToDoSomething:
@@ -404,7 +404,7 @@ To protect against this, we should do two things:
 
 1. Celery tasks should always be called by passing kwargs (not args). Eg:
 
-```python
+```
 some_tasks.apply_async(kwargs={'arg1': 1, 'arg2': 2}, queue="some-queue")
 ```
 
@@ -453,14 +453,14 @@ domain layer).
 
 That is, prefer:
 
-```python
+```
 from path.to.some.module import (
     thing1, thing2, thing3, thing4)
 ```
 
 over:
 
-```python
+```
 from path.to.some.module import \
     thing1, thing2, thing3, thing4
 ```
@@ -469,7 +469,7 @@ from path.to.some.module import \
 
 Usually, you should import modules rather than their objects. Instead of:
 
-```python
+```
 from django.http import (
     HttpResponse, HttpResponseRedirect, HttpResponseBadRequest)
 from django.shortcuts import render, get_object_or_404
@@ -477,7 +477,7 @@ from django.shortcuts import render, get_object_or_404
 
 prefer:
 
-```python
+```
 from django import http, shortcuts
 ```
 
@@ -491,7 +491,7 @@ as an indirect collaborator (several calls away) is patched.
 
 Eg:
 
-```python
+```
 import mock
 from somepackage import somemodule
 
@@ -510,7 +510,7 @@ Avoiding object imports isn't a hard and fast rule. Sometimes it can significant
 impair readability. This is particularly the case with commonly used objects
 in the standard library. Some examples where you should import the object instead:
 
-```python
+```
 from decimal import Decimal
 from typing import Optional, Tuple, Dict
 from collections import defaultdict
@@ -537,7 +537,7 @@ that there's logic in the view layer that needs extracting.
 
 Avoid this pattern:
 
-```python
+```
 
 def do_something(*args, **kwargs):
     if thing_done_already():
@@ -554,7 +554,7 @@ the action was successful or not. This leads to subtle bugs.
 It's much better to be explicit and use exceptions to indicate that an action
 couldn't be taken. Eg:
 
-```python
+```
 
 def do_something(*args, **kwargs):
     if thing_done_already():
@@ -572,7 +572,7 @@ If it _really_ doesn't matter if the action succeeds or fails from the caller's
 point-of-view (a "fire-and-forget" action), then use a wrapper function that
 delegates to the main function but swallows all exceptions:
 
-```python
+```
 
 def do_something(*args, **kwargs):
     try:
@@ -607,7 +607,7 @@ There is a difference:
 
 It sometimes makes sense to use both next to each other, eg:
 
-```python
+```
 def do_that_thing():
     """
     Perform some action and return some thing
@@ -649,7 +649,7 @@ Eg `octoenergy/path/to/something.py` should have tests in
 
 For each function/class being tested, use a test class to group its tests. Eg:
 
-```python
+```
 from somewhere import some_function
 
 
@@ -686,7 +686,7 @@ A unit test has three steps:
 To aid readability, organise your test methods in this way, adding a blank line
 between each step. Trivial example:
 
-```python
+```
 class TestSomeFunction:
 
     def test_does_something_in_a_certain_way(self):
@@ -704,7 +704,7 @@ This applies less to functional tests which can make many calls to the system.
 For functional tests, use comments and blank lines to ensure each step of the
 test is easily understandable. Eg:
 
-```python
+```
 def test_some_longwinded_process(support_client, factory):
     # Create an electricity-only account with one agreement
     account = factory.create_electricity_only_account()


### PR DESCRIPTION
Remove language from code snippets so that [Catalog](https://docs.catalog.style/configuration/pages) styleguide pageLoader React component can parse markdown files properly