### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "octo-styleguide",
+  "version": "1.0.0",
+  "description": "Octopus Energy styleguide",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/octoenergy/styleguide.git"
+  },
+  "author": "octoenergy",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/octoenergy/styleguide/issues"
+  },
+  "homepage": "https://github.com/octoenergy/styleguide#readme"
+}


### PR DESCRIPTION
# Summary 
Add package.json so that the styleguide repo can be installed as an npm dependency.
NPM complains otherwise (error below):
```
npm ERR! package.json Non-registry package missing package.json: git+ssh://git@github.com/octoenergy/styleguide.git.
```

## Why?
[New consumer site styleguide](https://github.com/octoenergy/consumer-site/pull/6298) will include our style conventions. [npm installing this private repo](https://stackoverflow.com/questions/23210437/npm-install-private-github-repositories-by-dependency-in-package-json) is the best way of making the markdown files available.

` "octo-styleguide": "git+https://git@github.com:octoenergy/styleguide.git"`