### PR TITLE
make class naming convention consistent

### DIFF
--- a/conventions/django.md
+++ b/conventions/django.md
@@ -76,7 +76,7 @@ from django.views import generic
 from . import forms
 
 
-class SetPassword(generic.FormView):
+class SetPasswordView(generic.FormView):
     form_class = forms.NewPasswordForm
 ```
 


### PR DESCRIPTION
the snippet showing class name suffixes would be even more exemplary using the suffix in both form class and view class