### PR TITLE
Set CircleCI checkout step method to full

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ jobs:
     docker:
       - image: cimg/python:3.11.4
     steps:
-      - checkout
+      - checkout:
+          method: full
       - run:
           name: Install pytest
           command: pip install pytest
@@ -18,7 +19,8 @@ jobs:
     docker:
       - image: tmaier/markdown-spellcheck:latest
     steps:
-      - checkout
+      - checkout:
+          method: full
       - run:
           name: Check spelling
           command: mdspell --report --ignore-numbers --ignore-acronyms "**/*.md"
@@ -27,7 +29,8 @@ jobs:
     docker:
       - image: tmknom/markdownlint:0.33.0
     steps:
-      - checkout
+      - checkout:
+          method: full
 
       # Note, we can't use a make target here as `make` isn't installed on this Docker image.
       - run:
@@ -38,7 +41,8 @@ jobs:
     docker:
       - image: tmknom/prettier:3.0.0
     steps:
-      - checkout
+      - checkout:
+          method: full
       - run:
           name: Check Prettier
           command: prettier --check .


### PR DESCRIPTION
CircleCI are introducing a breaking change to the checkout step where the default clone method will soon be blobless instead of full, more info [here](https://circleci.com/changelog/introducing-a-faster-checkout-option/?utm_medium=email&_hsenc=p2ANqtz-86y5jrqjfjV0Pc4FvOyMoyOlCAV-eDhwEj8ofY74xMrWX3k8cUvHY4XwkdgQxFaJNHbw4hddLdN4dQ1YLgg1D4mxN7zzkgmWJBVPnPXIZU-t2k0H8&_hsmi=384508146&utm_content=384508146&utm_source=hs_email).
This PR mitigates the breaking change by setting the checkout method to full.

If you need a full clone, approve and merge this PR.
If a blobless checkout is sufficient and you wish to benefit from the associated performance enhancements: set the method to blobless, or, close this PR and use the new default value.

This PR was generated automatically.
Feel free to reach out to me on slack (@charlotte.dodd).